### PR TITLE
fix checkpointing offset

### DIFF
--- a/examples/train_ssl.py
+++ b/examples/train_ssl.py
@@ -704,7 +704,7 @@ class ImageNetTrainer:
                 self.log(dict(stats,  **extra_dict))
             self.eval_and_log(stats, extra_dict)
             # Run checkpointing
-            self.checkpoint(epoch)
+            self.checkpoint(epoch + 1)
         if self.gpu == 0:
             ch.save(self.model.state_dict(), self.log_folder / 'final_weights.pt')
 


### PR DESCRIPTION
The restarting job will otherwise restart at epoch `epoch` with the weights obtained at the end of `epoch` in the stopped job, hence silently adding one epoch to the training