### PR TITLE
Fix for error generated when using RandomHorizontalFlip with seed

### DIFF
--- a/ffcv/transforms/flip.py
+++ b/ffcv/transforms/flip.py
@@ -58,6 +58,7 @@ class RandomHorizontalFlip(Operation):
                     dst[i] = images[i]
             return dst
         flip.is_parallel = True
+        flip.with_counter = True
         return flip
 
 


### PR DESCRIPTION
Added ```flip.with_counter = True``` at line 61 of flip.py, which fixes the error which occurs as described in #5 .

This is a very small change-- but added it just in case.