### PR TITLE
Test `torch.nn.Module` wrapper

### DIFF
--- a/test_nn_module.py
+++ b/test_nn_module.py
@@ -1,0 +1,40 @@
+import os
+
+from torch import nn
+
+from ffcv.fields.decoders import SimpleRGBImageDecoder
+from ffcv.loader import Loader, OrderOption
+
+
+class DummyModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, img):
+        return img
+
+
+def main():
+    img_pipeline = [SimpleRGBImageDecoder(), DummyModule()]
+    pipelines = {
+        'image': img_pipeline,
+        'image2': img_pipeline.copy(),
+    }
+
+    loader = Loader(
+        path=os.environ['BETON_PATH'],
+        batch_size=256,
+        num_workers=12,
+        order=OrderOption.QUASI_RANDOM,
+        pipelines=pipelines,
+        custom_field_mapper={'image2': 'image'},
+    )
+
+    data_iter = iter(loader)
+    data = next(data_iter)
+    print(f"{len(data)=}")
+    print(f"{[d.shape for d in data]}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I haven't been able to successfully use the `ModuleWrapper` from `ffcv.transforms.module`. This script demonstrates that it doesn't seem to work, e.g. I always get this error:
```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/opt/envs/mlb/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/workspace/FFCV-SSL/ffcv/loader/epoch_iterator.py", line 85, in run
    result = self.run_pipeline(b_ix, ixes, slot, events[slot], slot)
  File "/workspace/FFCV-SSL/ffcv/loader/epoch_iterator.py", line 141, in run_pipeline
    result = code(*args)
  File "/opt/envs/mlb/lib/python3.10/site-packages/numba/core/dispatcher.py", line 468, in _compile_for_args
    error_rewrite(e, 'typing')
  File "/opt/envs/mlb/lib/python3.10/site-packages/numba/core/dispatcher.py", line 409, in error_rewrite
    raise e.with_traceback(None)
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
Failed in nopython mode pipeline (step: nopython frontend)
Untyped global name 'self': Cannot determine Numba type of <class 'ffcv.transforms.module.ModuleWrapper'>

File "ffcv/transforms/module.py", line 25:
        def apply_module(inp, _):
            res = self.module(inp)
            ^

During: resolving callee type: type(CPUDispatcher(<function ModuleWrapper.generate_code.<locals>.apply_module at 0x7f653d959990>))
During: typing of call at  (2)

During: resolving callee type: type(CPUDispatcher(<function ModuleWrapper.generate_code.<locals>.apply_module at 0x7f653d959990>))
During: typing of call at  (2)


File "/workspace/FFCV-SSL", line 2:
<source missing, REPL/exec in use?>
```