### PR TITLE
Fixing issues with rotate transform

### DIFF
--- a/ffcv/transforms/__init__.py
+++ b/ffcv/transforms/__init__.py
@@ -15,6 +15,7 @@ from .solarization import RandomSolarization, LabelSolarization
 from .translate import RandomTranslate, LabelTranslate
 from .gaussian_blur import GaussianBlur, LabelGaussianBlur
 from .erasing import RandomErasing
+from .rotate import Rotate
 
 __all__ = ['ToTensor', 'ToDevice',
            'ToTorchImage', 'NormalizeImage',
@@ -28,4 +29,4 @@ __all__ = ['ToTensor', 'ToDevice',
            'RandomSolarization', 'LabelSolarization',
            'RandomTranslate', 'LabelTranslate',
            'GaussianBlur', 'LabelGaussianBlur',
-           'RandomErasing']
+           'RandomErasing', 'Rotate']

--- a/ffcv/transforms/rotate.py
+++ b/ffcv/transforms/rotate.py
@@ -35,9 +35,9 @@ class Rotate(Operation):
         angle = self.angle
         seed = self.seed
 
-        def rotate(images, dst, indices):
+        def rotate(images, dst, counter):
             if seed is not None:
-                np.random.seed(seed + indices)
+                np.random.seed(seed + counter)
                 values = np.zeros(images.shape[0])
                 angles = np.zeros(images.shape[0])
                 for i in range(images.shape[0]):
@@ -69,12 +69,18 @@ class Rotate(Operation):
                                 np.int32(coords[j, 1]) + W // 2,
                                 :,
                             ] = images[i, src_coords[j, 0], src_coords[j, 1], :]
+                        else:
+                            dst[i,
+                                np.int32(coords[j, 0]) + H // 2,
+                                np.int32(coords[j, 1]) + W // 2,
+                                :,
+                                ] = 0.
                 else:
                     dst[i] = images[i]
             return dst
 
         rotate.is_parallel = True
-        rotate.with_indices = True
+        rotate.with_counter = True
         return rotate
 
     def declare_state_and_memory(

--- a/ffcv/transforms/rotate.py
+++ b/ffcv/transforms/rotate.py
@@ -37,7 +37,7 @@ class Rotate(Operation):
 
         def rotate(images, dst, counter):
             if seed is not None:
-                np.random.seed(seed + counter)
+                random.seed(seed + counter)
                 values = np.zeros(images.shape[0])
                 angles = np.zeros(images.shape[0])
                 for i in range(images.shape[0]):


### PR DESCRIPTION
Addresses #10. 

## Summary of changes
1. [transforms/__init__.py](ffcv/transforms/__init__.py): Added rotate so that it can be imported like other transforms.
2. [transforms/rotate.py](ffcv/transforms/rotate.py): 
    - *Seeding bug fix*: Changed seeding from indices to counter to avoid numba error.
    - *Spurious Nans bug fix*: Added an else condition to set pixel values in dst that are not available in src to 0.

## Key result
Top row show the original Cifar-10 images. Middle row show the rotated images (with seed 7) and the bottom row show the same images undergoing the rotation transform with seed 7, ensuring that setting the seed ensures that the images are rotated by the same amount. 
<p align="center">
<img src="https://github.com/facebookresearch/FFCV-SSL/assets/6922389/e6eaecab-5bb4-404f-a5aa-ed7468b38869" width="700" height="575"/>
</p>

This should close #10!
